### PR TITLE
extract the Microsoft BusyStatus

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -174,6 +174,12 @@ module.exports = NodeHelper.create({
       ev.isFullday = isFullday
       if (isFullday) {
       }
+
+      // import the Microsoft property X-MICROSOFT-CDO-BUSYSTATUS, fall back to "BUSY" in case none was found
+      // possible values are 'FREE'|'TENTATIVE'|'BUSY'|'OOF' acording to
+      // https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/cd68eae7-ed65-4dd3-8ea7-ad585c76c736
+      ev.ms_busystatus = ri.component.getFirstPropertyValue('x-microsoft-cdo-busystatus') || 'BUSY'
+
       ev.uid = (ri.uid)
         ? calendar.uid + ":" + ev.startDate + ":" + ev.endDate + ":" + ri.uid
         : calendar.uid + ":" + ev.startDate + ":" + ev.endDate + ":" + ev.title


### PR DESCRIPTION
this makes the BusyStatus custom attribute presented by Microsoft
available as property 'event.ms_busystatus'.

Events that don't have this property in it's source will always get the
status 'BUSY' that most events in a Outlook-Driven environment would
have.

The possible values found in the Microsoft documentation are:
 - 'FREE' - User marked this event as not affecting his availability to others
 - 'TENTATIVE' - User is not sure if he/she will be in attendence
 - 'BUSY' - User has decided to attend
 - 'OOF' - User is "not in the office" during this event

The use case for myself is to only include BUSY events on my Mirror, as
all other types are either not fix yet or don't actually affect my
schedule.