### PR TITLE
add a way to deduplicate events

### DIFF
--- a/MMM-CalendarExt2.js
+++ b/MMM-CalendarExt2.js
@@ -172,6 +172,7 @@ Module.register("MMM-CalendarExt2", {
 
     rotateInterval: 0, //when 0, autoRotate will be disabled.
     updateInterval: 1000 * 60, //If not rotated, this interval will be used for update content
+    deduplicateEventsOn: [],
     defaultSet: {
       calendar:{},
       scene:{},

--- a/doc/Configuration/Others.md
+++ b/doc/Configuration/Others.md
@@ -6,6 +6,40 @@
 |rotateInterval |Number (ms) |1000*60 |0 |If set, `Scene` will be rotated per this time. If set as `0`, auto-rotation among the scenes will be disabled.
 |updateInterval |Number (ms) |1000* 60 *10 |1000*60 |If not auto-rotated, this interval will be used for updating content.
 |firstDrawingDelay |Number (ms) |1000*10 |1000 |Sometimes, calendar parsing could be somewhat late. You can set delay for first drawing to wait calendar parsing
+|deduplicateEventsOn | Array | `["startDate","endDate","duration","title","location"]` | `[]` | define which attributes must be equal in order to remove duplicate events
+
+# Event Deduplication
+
+Please read [pull request #18](https://github.com/eouia/MMM-CalendarExt2/pull/18)
+on the motivation for event deduplication.
+
+Essentially you need to specify which of the [event attributes](../Event-Object.md)
+need to be checked for equality before and event is marked as duplicate.
+
+This process is quite CPU-intensive, so the example value above was carefully
+chosen to use cheap number comparisons before making costlier string
+comparisons.
+
+How does this actually work? The events are first sorted by the attributes you
+specified. Afterwards each event get's checked against the event that was
+ordered before it. Then each event that is identical to it's predecessor gets
+dropped.
+
+Note: The implementors use case expects that events originate from different
+calendars. So when a duplicate event gets removed, it's `calendarName` gets
+appended to the `calendarName` of the kept event. So if you specify calendars
+in a view you need to also specify the possible calendar combinations.
+
+Imagine the following:
+
+| field        | event 1     | event 2     | resulting event |
+| ---          | ---         | ---         | ---             |
+| startDate    | 1553891393  | 1553891393  | 1553891393      |
+| endDate      | 1553894993  | 1553894993  | 1553894993      |
+| duration     | 3600        | 3600        | 3600            |
+| title        | `testEvent` | `testEvent` | `testEvent`     |
+| location     | `Dresden`   | `Dresden`   | `Dresden`       |
+| calendarName | `Anja`      | `Andre`     | *`Anja\|Andre`*    |
 
 
 ## Example of whole configuration for real usage


### PR DESCRIPTION
this seems to be the best way in my understanding, allowing the user to
decide on which event properties a deduplication should be decided on.

Of cause using this has a gotcha: the calendarName property is being
modified. This is purely driven by my use case. But this could be made
configurable as well (thinking about `config.deduplicationMergeProps`).

This PR is still a work-in-progress, as I am not a Javascript guy and the approach might be solved much easier with the right knowledge. Also the design for the config options is not final (has anyone better ideas?).

I welcome every kind of feedback, so please tell me if this is taking it too far or if my use case is too obscure.