### PR TITLE
change upcoming maxDays semantics to "end of day"

### DIFF
--- a/CALEXT2_View.js
+++ b/CALEXT2_View.js
@@ -558,7 +558,7 @@ class ViewUpcoming extends ViewAgenda {
   }
 
   filterEvents(events) {
-    var until = moment().add(this.config.maxDays, "day")
+    var until = moment().add(this.config.maxDays, "day").endOf('day')
     var filtered = super.filterEvents(events)
     filtered = filtered.filter((e)=>{
       if (moment.unix(e.startDate).isBetween(moment(), until)) return true


### PR DESCRIPTION
I noticed that events appear in the upcoming view only, if they are in a windows defined by `now + 24h` (given `maxDays: 1`).

My original impression was, that `maxDays` means the full day, so if I specify a `1` there, it means upcoming would show all events of tomorrow.

I hope this change fits your intentions as well, else we might need to find another way to make this configurable.